### PR TITLE
Register did:web:app.certivo.com.br (Certivo)

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -125,6 +125,11 @@
             "name": "Proof of Knowledge Test",
             "location": "Argentina",
             "url": "https://www.pok.tech/"
+        },
+        "did:web:app.certivo.com.br": {
+            "name": "Certivo",
+            "location": "Florianópolis, SC, Brazil",
+            "url": "https://certivo.com.br"
         }
     }
 }


### PR DESCRIPTION
## Summary

Adds [Certivo](https://certivo.com.br) as a registered issuer, identified by `did:web:app.certivo.com.br`.

## About the issuer

Certivo is a B2B SaaS platform based in Florianópolis, Brazil, focused on digital certificate issuance and verification for events, courses, and professional training programs in Brazil and Latin America.

## Technical details

- **DID:** `did:web:app.certivo.com.br`
- **DID document:** https://app.certivo.com.br/.well-known/did.json
- **Verification method:** `did:web:app.certivo.com.br#key-1` (Ed25519 Multikey)
- **Credential format:** W3C Verifiable Credentials v2 + Open Badges v3
- **Cryptosuite:** `eddsa-rdfc-2022` (DataIntegrityProof, digitalbazaar reference libraries)
- **Sample credential endpoint:** `https://app.certivo.com.br/c/{hash}/badge.json` (CORS-open, `application/ld+json`)
- Credentials validate cleanly against DCC VerifierPlus (`valid_signature: true`).

## Verification path

1. A verifier fetches a credential at `/c/{hash}/badge.json`.
2. The `proof.verificationMethod` is `did:web:app.certivo.com.br#key-1`.
3. Resolving `did:web:app.certivo.com.br` fetches `/.well-known/did.json`, which publishes the Multikey and lists the VM in `assertionMethod`.

## Contact

- Paulo Vieira — paulo@splendor.io

Happy to provide a sample signed credential URL on request.